### PR TITLE
fix: 修正 freeListSize_ 的计数逻辑为 batchNum - 1

### DIFF
--- a/v3/src/ThreadCache.cpp
+++ b/v3/src/ThreadCache.cpp
@@ -77,7 +77,7 @@ void* ThreadCache::fetchFromCentralCache(size_t index)
     if (!start) return nullptr;
 
     // 更新自由链表大小
-    freeListSize_[index] += batchNum; // 增加对应大小类的自由链表大小
+    freeListSize_[index] += batchNum-1; // 增加对应大小类的自由链表大小
 
     // 取一个返回，其余放入线程本地自由链表
     void* result = start;


### PR DESCRIPTION
### 描述（Description）

### 这个 PR 的作用
本 PR 修复了 `ThreadCache::fetchFromCentralCache` 函数中自由链表大小计数 (`freeListSize_`) 的更新逻辑。

### 问题背景
在原始实现中，代码如下：
```cpp
freeListSize_[index] += batchNum;
````

这里的计数逻辑存在问题：函数从 CentralCache 批量获取了 `batchNum` 个对象，其中 **1 个对象会立即返回给调用方**，剩余的 (batchNum - 1) 个对象才会放入当前线程的自由链表。但原始代码将所有对象都计入了 `freeListSize_`，导致链表大小被高估。

### 修改方案

将上述逻辑修改为：

```cpp
freeListSize_[index] += batchNum - 1;
```

### 修改的意义

* **计数更准确**：保证 `freeListSize_` 与实际存入自由链表的对象数保持一致。
* **避免潜在问题**：防止在内存分配统计、调试和性能分析中出现数据不一致。
* **改动范围小**：仅涉及一行逻辑修改，不影响其他功能。

### 额外说明

* 本次修改不引入任何新的依赖。
* 已验证修改后的代码能够正常编译和运行。
* 该修复为一次性逻辑修正，对后续维护具有积极意义。


