### PR TITLE
fix: CentralCache::fetchRange 使用引用返回实际 batchNum，修正 freeListSize_ 统计错误

### DIFF
--- a/v3/include/CentralCache.h
+++ b/v3/include/CentralCache.h
@@ -14,7 +14,7 @@ public:
         return instance;
     }
 
-    void* fetchRange(size_t index, size_t batchNum);
+    void* fetchRange(size_t index, size_t &batchNum);
     void returnRange(void* start, size_t size, size_t bytes);
 
 private:

--- a/v3/src/CentralCache.cpp
+++ b/v3/src/CentralCache.cpp
@@ -9,7 +9,7 @@ namespace Kama_memoryPool
 // 每次从PageCache获取span大小（以页为单位）
 static const size_t SPAN_PAGES = 8;
 
-void* CentralCache::fetchRange(size_t index, size_t batchNum)
+void* CentralCache::fetchRange(size_t index, size_t &batchNum)
 {
     // 索引检查，当索引大于等于FREE_LIST_SIZE时，说明申请内存过大应直接向系统申请
     if (index >= FREE_LIST_SIZE || batchNum == 0) 
@@ -86,7 +86,7 @@ void* CentralCache::fetchRange(size_t index, size_t batchNum)
                 current = *reinterpret_cast<void**>(current);
                 count++;
             }
-
+            batchNum =count;
             if (prev) // 当前centralFreeList_[index]链表上的内存块大于batchNum时需要用到 
             {
                 *reinterpret_cast<void**>(prev) = nullptr;

--- a/v3/src/ThreadCache.cpp
+++ b/v3/src/ThreadCache.cpp
@@ -77,7 +77,7 @@ void* ThreadCache::fetchFromCentralCache(size_t index)
     if (!start) return nullptr;
 
     // 更新自由链表大小
-    freeListSize_[index] += batchNum; // 增加对应大小类的自由链表大小
+    freeListSize_[index] += batchNum-1; // 增加对应大小类的自由链表大小
 
     // 取一个返回，其余放入线程本地自由链表
     void* result = start;


### PR DESCRIPTION
### 修改内容
- 将 `CentralCache::fetchRange` 的 `batchNum` 参数改为引用传递 (`size_t& batchNum`)。
- 使得 `batchNum` 能够反映实际分配到的内存块数量。
- 修复了 `ThreadCache::freeListSize_` 在内存不足时统计错误的问题。

### 修改原因
之前 `batchNum` 总是假设为请求数量，即使中心缓存没有足够的空闲块也会错误更新自由链表大小，导致统计不准确，甚至潜在内存管理问题。

### 影响范围
- `ThreadCache::fetchFromCentralCache` 更新空闲链表大小将更加准确。
- 提高了内存池在多线程高并发下的稳定性和一致性。

### 备注
这种改动保证了分配方（CentralCache）能够直接告知调用方真实的分配数量，更符合职责分工，也避免了调用方自行推测的风险。
